### PR TITLE
Don't use extra memory storing images zoomed in over 100%

### DIFF
--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -74,39 +74,23 @@ class ImagePyramid:
         wider than the displayed window, so that the center of the window is
         the center of the image.
         """
-        print("\ntop of function:")
-        print("top_left_x", top_left_x)
-        print("top_left_y", top_left_y)
-        print("height", height)
-        print("width", width)
         zoom_level = self._zoom_level
-        print("zoom_level", zoom_level)
         scale = 1 if zoom_level >= 0 else 2 ** (-zoom_level)
-        print("scale", scale)
         current_data = self._pyramid[max(0, zoom_level)]
         nr, nc = current_data.shape
         nr *= scale
         nc *= scale
 
-        print("nr", nr)
-        print("nc", nc)
-
         min_x = max(0,  top_left_x -     width)
         min_y = max(0,  top_left_y -     height)
         max_x = min(nc, top_left_x + 2 * width)
         max_y = min(nr, top_left_y + 2 * height)
-        print("min_x", min_x)
-        print("min_y", min_y)
-        print("max_x", max_x)
-        print("max_y", max_y)
 
         if zoom_level >= 0:
-            print("normal case")
             # No need to do anything special: just return the relevant data
             submatrix = current_data[min_y:max_y, min_x:max_x]
             return submatrix, min_x, min_y
 
-        print("unusual case!")
         # Otherwise, we're zoomed in more than 100%. Grab the data we want,
         # then duplicate it a bunch.
 
@@ -114,16 +98,10 @@ class ImagePyramid:
         min_y //= scale
         max_x //= scale
         max_y //= scale
-        print("min_x", min_x)
-        print("min_y", min_y)
-        print("max_x", max_x)
-        print("max_y", max_y)
         # Avoid roundoff errors: make the top part 1 wider, and if it's a few
         # pixels larger than expected, no one will notice.
         max_x += 1
         max_y += 1
-        print("max_x", max_x)
-        print("max_y", max_y)
 
         submatrix = current_data[min_y:max_y, min_x:max_x]
 
@@ -135,10 +113,7 @@ class ImagePyramid:
                     new_submatrix[r::2, c::2] = submatrix
             submatrix = new_submatrix
 
-        ret_val = submatrix, min_x * scale, min_y * scale
-
-        print("ret_val", ret_val[0].shape, ret_val[1], ret_val[2])
-        return ret_val
+        return submatrix, min_x * scale, min_y * scale
 
     def zoom(self, amount):
         """

--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -75,11 +75,11 @@ class ImagePyramid:
         the center of the image.
         """
         zoom_level = self._zoom_level
-        scale = 1 if zoom_level >= 0 else 2 ** (-zoom_level)
+        scale = max(0, -zoom_level)
         current_data = self._pyramid[max(0, zoom_level)]
         nr, nc = current_data.shape
-        nr *= scale
-        nc *= scale
+        nr <<= scale
+        nc <<= scale
 
         min_x = max(0,  top_left_x -     width)
         min_y = max(0,  top_left_y -     height)
@@ -94,12 +94,13 @@ class ImagePyramid:
         # Otherwise, we're zoomed in more than 100%. Grab the data we want,
         # then duplicate it a bunch.
 
-        min_x //= scale
-        min_y //= scale
-        max_x //= scale
-        max_y //= scale
-        # Avoid roundoff errors: make the top part 1 wider, and if it's a few
-        # pixels larger than expected, no one will notice.
+        min_x >>= scale
+        min_y >>= scale
+        max_x >>= scale
+        max_y >>= scale
+        # Avoid roundoff errors: make the truncated edges 1 pixel wider before
+        # expanding, and if it's a few pixels larger than expected, no one
+        # will notice.
         max_x += 1
         max_y += 1
 
@@ -113,7 +114,7 @@ class ImagePyramid:
                     new_submatrix[r::2, c::2] = submatrix
             submatrix = new_submatrix
 
-        return submatrix, min_x * scale, min_y * scale
+        return submatrix, min_x << scale, min_y << scale
 
     def zoom(self, amount):
         """

--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -74,15 +74,20 @@ class ImagePyramid:
         wider than the displayed window, so that the center of the window is
         the center of the image.
         """
-        print("top of function:")
+        print("\ntop of function:")
         print("top_left_x", top_left_x)
         print("top_left_y", top_left_y)
         print("height", height)
         print("width", width)
         zoom_level = self._zoom_level
         print("zoom_level", zoom_level)
+        scale = 1 if zoom_level >= 0 else 2 ** (-zoom_level)
+        print("scale", scale)
         current_data = self._pyramid[max(0, zoom_level)]
         nr, nc = current_data.shape
+        nr *= scale
+        nc *= scale
+
         print("nr", nr)
         print("nc", nc)
 
@@ -104,10 +109,6 @@ class ImagePyramid:
         print("unusual case!")
         # Otherwise, we're zoomed in more than 100%. Grab the data we want,
         # then duplicate it a bunch.
-        zoom_level *= -1
-        print("zoom_level", zoom_level)
-        scale = 2 ** zoom_level
-        print("scale", scale)
 
         min_x //= scale
         min_y //= scale
@@ -127,14 +128,17 @@ class ImagePyramid:
         submatrix = current_data[min_y:max_y, min_x:max_x]
 
         # Now, duplicate the data until it's grown to the right size.
-        for _ in range(zoom_level):
+        for _ in range(-zoom_level):
             new_submatrix = numpy.zeros([2 * x for x in submatrix.shape])
             for r in [0, 1]:
                 for c in [0, 1]:
                     new_submatrix[r::2, c::2] = submatrix
             submatrix = new_submatrix
 
-        return submatrix, min_x * scale, min_y * scale
+        ret_val = submatrix, min_x * scale, min_y * scale
+
+        print("ret_val", ret_val[0].shape, ret_val[1], ret_val[2])
+        return ret_val
 
     def zoom(self, amount):
         """

--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -7,23 +7,9 @@ class ImagePyramid:
 
     def __init__(self, matrix):
         self._pyramid = []  # A list of `matrix` at different zoom levels
-
-        """
-        # Start by zooming into the matrix so that each pixel of the original
-        # takes up multiple pixels on the screen.
-        zoomed_in_matrix = matrix
-        for _ in range(self._ZOOMED_IN_LEVELS):
-            next_level = numpy.zeros([2 * x for x in zoomed_in_matrix.shape])
-            for r in [0, 1]:
-                for c in [0, 1]:
-                    next_level[r::2, c::2] = zoomed_in_matrix
-            self._pyramid.append(next_level)
-            zoomed_in_matrix = next_level
-        self._pyramid.reverse()  # The most zoomed-in part comes at the base
-        """
         self._pyramid.append(matrix)
 
-        # Now, zoom out and make the matrix smaller and smaller
+        # Zoom out and make the matrix smaller and smaller
         while max(matrix.shape) >= 2 * self._MIN_MAP_SIZE:
             # Combine 2x2 squares of pixels to make the next level.
             nr, nc = [(value // 2) * 2 for value in matrix.shape]

--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -61,7 +61,7 @@ class ImagePyramid:
 
         # self._zoom_level is the index into self._pyramid to get the current
         # image.
-        self._zoom_level = self._ZOOMED_IN_LEVELS  # Start at 100%
+        self._zoom_level = 0  # Start at 100%
         self._max_zoom_level = len(self._pyramid) - 1
 
     def get_submatrix(self, top_left_x, top_left_y, height, width):
@@ -74,37 +74,8 @@ class ImagePyramid:
         wider than the displayed window, so that the center of the window is
         the center of the image.
         """
-        zoom_level = self._zoom_level - self._ZOOMED_IN_LEVELS
-        if zoom_level < 0:
-            # We're zoomed in more than 100%. Grab the data we want, then
-            # duplicate it a bunch.
-            zoom_level *= -1
-            scale = 2 ** zoom_level
-
-            current_data = self._pyramid[0]
-            nr, nc = current_data.shape
-
-            # Avoid roundoff errors: make the top part 1 wider, and if it's a few pixels more
-            # detailed than expected, no one will notice.
-            min_x = max(0,  top_left_x -     width)  // scale
-            min_y = max(0,  top_left_y -     height) // scale
-            max_x = min(nc, top_left_x + 2 * width)  // scale + 1
-            max_y = min(nr, top_left_y + 2 * height) // scale + 1
-
-            submatrix = current_data[min_y:max_y, min_x:max_x]
-
-            for _ in range(zoom_level):
-                new_submatrix = numpy.zeros([2 * x for x in submatrix.shape])
-                for r in [0, 1]:
-                    for c in [0, 1]:
-                        new_submatrix[r::2, c::2] = submatrix
-                submatrix = new_submatrix
-
-            return submatrix, min_x * scale, min_y * scale
-
-        # Otherwise, we're zoomed in at most 100%. Grab the data from the
-        # relevant part of the pyramid.
-        current_data = self._pyramid[zoom_level]
+        zoom_level = self._zoom_level
+        current_data = self._pyramid[max(0, zoom_level)]
         nr, nc = current_data.shape
 
         min_x = max(0,  top_left_x -     width)
@@ -112,8 +83,36 @@ class ImagePyramid:
         max_x = min(nc, top_left_x + 2 * width)
         max_y = min(nr, top_left_y + 2 * height)
 
+        if zoom_level >= 0:
+            # No need to do anything special: just return the relevant data
+            submatrix = current_data[min_y:max_y, min_x:max_x]
+            return submatrix, min_x, min_y
+
+        # Otherwise, we're zoomed in more than 100%. Grab the data we want,
+        # then duplicate it a bunch.
+        zoom_level *= -1
+        scale = 2 ** zoom_level
+
+        min_x //= scale
+        min_y //= scale
+        max_x //= scale
+        max_y //= scale
+        # Avoid roundoff errors: make the top part 1 wider, and if it's a few
+        # pixels larger than expected, no one will notice.
+        max_x += 1
+        max_y += 1
+
         submatrix = current_data[min_y:max_y, min_x:max_x]
-        return submatrix, min_x, min_y
+
+        # Now, duplicate the data until it's grown to the right size.
+        for _ in range(zoom_level):
+            new_submatrix = numpy.zeros([2 * x for x in submatrix.shape])
+            for r in [0, 1]:
+                for c in [0, 1]:
+                    new_submatrix[r::2, c::2] = submatrix
+            submatrix = new_submatrix
+
+        return submatrix, min_x * scale, min_y * scale
 
     def zoom(self, amount):
         """
@@ -124,8 +123,8 @@ class ImagePyramid:
         # race conditions.
         self._zoom_level += amount
         self._zoom_level = min(self._zoom_level, self._max_zoom_level)
-        self._zoom_level = max(self._zoom_level, 0)
+        self._zoom_level = max(self._zoom_level, -self._ZOOMED_IN_LEVELS)
         return (self._zoom_level != orig_zoom_level)
 
     def get_zoom_level(self):
-        return self._zoom_level - self._ZOOMED_IN_LEVELS
+        return self._zoom_level

--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -74,33 +74,55 @@ class ImagePyramid:
         wider than the displayed window, so that the center of the window is
         the center of the image.
         """
+        print("top of function:")
+        print("top_left_x", top_left_x)
+        print("top_left_y", top_left_y)
+        print("height", height)
+        print("width", width)
         zoom_level = self._zoom_level
+        print("zoom_level", zoom_level)
         current_data = self._pyramid[max(0, zoom_level)]
         nr, nc = current_data.shape
+        print("nr", nr)
+        print("nc", nc)
 
         min_x = max(0,  top_left_x -     width)
         min_y = max(0,  top_left_y -     height)
         max_x = min(nc, top_left_x + 2 * width)
         max_y = min(nr, top_left_y + 2 * height)
+        print("min_x", min_x)
+        print("min_y", min_y)
+        print("max_x", max_x)
+        print("max_y", max_y)
 
         if zoom_level >= 0:
+            print("normal case")
             # No need to do anything special: just return the relevant data
             submatrix = current_data[min_y:max_y, min_x:max_x]
             return submatrix, min_x, min_y
 
+        print("unusual case!")
         # Otherwise, we're zoomed in more than 100%. Grab the data we want,
         # then duplicate it a bunch.
         zoom_level *= -1
+        print("zoom_level", zoom_level)
         scale = 2 ** zoom_level
+        print("scale", scale)
 
         min_x //= scale
         min_y //= scale
         max_x //= scale
         max_y //= scale
+        print("min_x", min_x)
+        print("min_y", min_y)
+        print("max_x", max_x)
+        print("max_y", max_y)
         # Avoid roundoff errors: make the top part 1 wider, and if it's a few
         # pixels larger than expected, no one will notice.
         max_x += 1
         max_y += 1
+        print("max_x", max_x)
+        print("max_y", max_y)
 
         submatrix = current_data[min_y:max_y, min_x:max_x]
 

--- a/image_pyramid.py
+++ b/image_pyramid.py
@@ -94,6 +94,7 @@ class ImagePyramid:
         # Otherwise, we're zoomed in more than 100%. Grab the data we want,
         # then duplicate it a bunch.
 
+        # First, scale all the coordinates to the actual data size.
         min_x >>= scale
         min_y >>= scale
         max_x >>= scale


### PR DESCRIPTION
This lets me view large files without running out of memory! For example, a C++ file I'm working on these days is 1300 lines long, and would OOM with the old version of this code but no longer does. Similarly, I'm now able to open a 4400-line Go file, and although that does take 1.1 gigabytes of RAM, it nonetheless works when it didn't previously!