### PR TITLE
Bugfixes and tweaks

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -6,15 +6,13 @@ import tkinter.font as tkfont
 from zoom_map import ZoomMap
 
 
-TAB_WIDTH = 4  # Width of a tab, in characters
-
-
 class _Context(tk.Text):
     """
     A display of surrounding code, with the relevant tokens highlighted. We will
     have one of these for the token(s) represented by the column of the mouse
     cursor, and another for its row.
     """
+    TAB_WIDTH = 4  # Width of a tab, in characters
     CONTEXT_COUNT = 3  # Lines to display before/after the current one
     # We hope we don't encounter files with more than 99,999 lines, but if we
     # do, alignment will be off.
@@ -42,7 +40,7 @@ class _Context(tk.Text):
         # everything else.
         font = tkfont.Font(font=self["font"])
         prelude_width = font.measure(" " * self.PRELUDE_WIDTH)
-        tab_width     = font.measure(" " * TAB_WIDTH)
+        tab_width     = font.measure(" " * self.TAB_WIDTH)
         self.config(tabs=f"{prelude_width +     tab_width} "
                          f"{prelude_width + 2 * tab_width}")
 
@@ -60,7 +58,8 @@ class _Context(tk.Text):
         # If we have tabs in the line, they will register as a single character
         # but take up multiple characters of width.
         tab_count = line_start.count("\t")
-        line_start = line_start[:self._text_width - tab_count * (TAB_WIDTH - 1)]
+        characters_on_line = self._text_width - tab_count * (self.TAB_WIDTH - 1)
+        line_start = line_start[:characters_on_line]
         updated_tab_count = line_start.count("\t")
         if tab_count != updated_tab_count:
             # We removed a tab while shortening the line to fit all the tabs.

--- a/gui.py
+++ b/gui.py
@@ -6,8 +6,7 @@ import tkinter.font as tkfont
 from zoom_map import ZoomMap
 
 
-# TODO: it would be nice to have tabs be 4 characters wide. Is this changeable?
-TAB_WIDTH = 8  # Width of a tab, in characters
+TAB_WIDTH = 4  # Width of a tab, in characters
 
 
 class _Context(tk.Text):
@@ -32,17 +31,18 @@ class _Context(tk.Text):
                          relief="ridge")
         self.pack()
 
-        # Set the tab width to 4 characters, not 8. Tcl/tk uses a list of tab
-        # stop distances, where each '\t' character will advance the text to
-        # the next tab stop. The units on these widths are not characters, but
-        # something more fine-grained (pixels? points?). The first tab should
-        # go 4 characters past the end of the prelude (the line number), and
-        # the next one should go 4 additional characters past that. Subsequent
-        # tab stops are inferred to be the same distance apart as the last two
-        # tab stops specified, so these two are sufficient for everything else.
+        # Set the tab width. Tcl/tk uses a list of tab stop distances, where
+        # each '\t' character will advance the text to the next tab stop. The
+        # units on these widths are not characters, but something more
+        # fine-grained (pixels? points?). The first tab should go TAB_WIDTH
+        # characters past the end of the prelude (the line number), and the
+        # next one should go TAB_WIDTH additional characters past that.
+        # Subsequent tab stops are inferred to be the same distance apart as
+        # the last two tab stops specified, so these two are sufficient for
+        # everything else.
         font = tkfont.Font(font=self["font"])
         prelude_width = font.measure(" " * self.PRELUDE_WIDTH)
-        tab_width     = font.measure(" " * 4)
+        tab_width     = font.measure(" " * TAB_WIDTH)
         self.config(tabs=f"{prelude_width +     tab_width} "
                          f"{prelude_width + 2 * tab_width}")
 

--- a/gui.py
+++ b/gui.py
@@ -17,6 +17,7 @@ class _Context(tk.Text):
     PRELUDE_WIDTH = LINE_NUMBER_WIDTH + 2  # Line number, colon, space
 
     def __init__(self, tk_parent, data, text_width, zoom_map):
+        self._text_width = text_width
         height = 2 * self.CONTEXT_COUNT + 1
         # NOTE: Lines longer than text_width get truncated, and any tokens off
         # the end don't get shown/highlighted.
@@ -49,7 +50,7 @@ class _Context(tk.Text):
         start = line_number - self.CONTEXT_COUNT - 1
         end   = line_number + self.CONTEXT_COUNT
         lines = ["{:>{}}: {}".format(i + 1, self.LINE_NUMBER_WIDTH,
-                                     self._lines[i][:80])
+                                     self._lines[i][:self._text_width])
                  if 0 <= i < len(self._lines) else ""
                  for i in range(start, end)]
         text = "\n".join(lines)

--- a/gui.py
+++ b/gui.py
@@ -53,13 +53,14 @@ class _Context(tk.Text):
         """
         Give back the part of line i that will fit in the display.
         """
-        line = self._lines[i]
-        line_start = line[:self._text_width]
+        line_start = self._lines[i][:self._text_width]
+
         # If we have tabs in the line, they will register as a single character
         # but take up multiple characters of width.
         tab_count = line_start.count("\t")
         characters_on_line = self._text_width - tab_count * (self.TAB_WIDTH - 1)
         line_start = line_start[:characters_on_line]
+
         updated_tab_count = line_start.count("\t")
         if tab_count != updated_tab_count:
             # We removed a tab while shortening the line to fit all the tabs.

--- a/gui.py
+++ b/gui.py
@@ -36,7 +36,6 @@ class _Context(tk.Text):
         tab_width = tkfont.Font(font=self["font"]).measure("    ")
         self.config(tabs=tab_width)
         # TODO: Use a NamedTuple?
-        self._tokens = data.tokens
         self._lines = data.lines
         self._boundaries = data.boundaries
         self._zoom_map = zoom_map

--- a/gui.py
+++ b/gui.py
@@ -90,8 +90,8 @@ class _Gui(tk.Frame):
 
         self._contexts = [_Context(self, data, text_width, self._map)
                           for data in (data_a, data_b)]
-        [self._map.bind(event, self._on_motion)
-                for event in ["<Motion>", "<Enter>"]]
+        for event in ("<Motion>", "<Enter>"):
+            self._map.bind(event, self._on_motion)
 
     def _on_motion(self, event):
         # We're using (row, col) format, so the first one changes with Y.

--- a/gui.py
+++ b/gui.py
@@ -51,7 +51,7 @@ class _Context(tk.Text):
 
     def _snip_line(self, i):
         """
-        Give back the part of line i that will fit in the display.
+        Returns the part of line i that will fit in the display.
         """
         line_start = self._lines[i][:self._text_width]
 


### PR DESCRIPTION
The big part here is that if you change the text width with `-tw`, it changed the width of the window but not the width of the text displayed! :flushed: So, that's now fixed. 

I also remember putting in these list comprehensions where I didn't care about the list itself, but only the side effects performed while constructing it. Why bother with the list at all!? Just make it a for loop.