### PR TITLE
Tweaks, bugfixes, and optimizations

### DIFF
--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -151,11 +151,8 @@ def get_lengths(matrix, is_single_file):
     # set in the original, and 1 if it was (it's either a lone pixel or it's on
     # the main diagonal of a file compared to itself).
     scores = (matrix != 0).astype(numpy.uint32)
-    for r in range(nr):
-        for c in range(nc):
-            segment = pixel_to_segment.get((r, c))
-            if segment is not None:
-                scores[r, c] = segment.size()
+    for (r, c), segment in pixel_to_segment.items():
+        scores[r, c] = segment.size()
     return scores
 
 

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -16,11 +16,11 @@ class _SegmentUnionFind:
     # roughly two thirds.
     __slots__ = ("_size", "_root", "top", "bottom")
 
-    def __init__(self, top, bottom, size):
+    def __init__(self, r, c, size):
         self._size = size
         self._root = None  # Might be another _SegmentUnionFind after merging
-        self.top = top
-        self.bottom = bottom
+        self.top = (r, c)
+        self.bottom = (r + size - 1, c + size - 1)
 
     def get_root(self):
         if self._root is None:
@@ -97,8 +97,7 @@ def _initialize_segments(matrix, is_single_file):
             if size == 1:  # Trivial segment: Don't bother trying to merge more.
                 continue
             # Otherwise, we've found a nontrivial segment. Add it in!
-            new_segment = _SegmentUnionFind(
-                    (r, c), (r + size - 1, c + size - 1), size)
+            new_segment = _SegmentUnionFind(r, c, size)
             for i in range(size):
                 segment_matrix[(r + i, c + i)] = new_segment
             segments.append(new_segment)

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -83,7 +83,7 @@ def _get_lengths(matrix, is_single_file):
                 continue  # Skip pixels on the main diagonal
 
             # See whether this segment is more than just a dot.
-            size = 0
+            size = 1
             while r + size < nr and c + size < nc and matrix[r + size, c + size] != 0:
                 size += 1
 
@@ -128,10 +128,6 @@ def _get_lengths(matrix, is_single_file):
         for c in range(nc):
             if segment_matrix[r, c] != 0:
                 scores[r, c] = segment_matrix[r, c].size()
-            elif r == c and is_single_file:
-                # We didn't merge these with anything, but should still count
-                # them in the final output.
-                scores[r, c] = 1
     return scores
 
 

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -153,6 +153,12 @@ def _get_lengths(matrix, is_single_file):
             segment = pixel_to_segment.get((r, c))
             if segment is not None:
                 scores[r, c] = segment.size()
+            elif matrix[r, c] != 0:
+                # The pixel was set in the original matrix, but we didn't
+                # create a segment for it.  Either it's a lone pixel by itself,
+                # or it's on the main diagonal of a file compared to itself.
+                # Either way, it scores 1.
+                scores[r, c] = 1
     return scores
 
 

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -12,7 +12,7 @@ class _SegmentUnionFind:
     """
     def __init__(self, top, bottom, size):
         self._size = size
-        self._root = None  # Might become a reference to another _SegmentUnionFind after merging
+        self._root = None  # Might be another _SegmentUnionFind after merging
         self.top = top
         self.bottom = bottom
 
@@ -56,9 +56,10 @@ class _SegmentUnionFind:
 
 def _initialize_segments(matrix, is_single_file):
     """
-    Returns a tuple of (segments, segment_matrix). These are a list of _SegmentUnionFinds and a 2D
-    array whose values are all either 0 or those same _SegmentUnionFinds, each of which has size at
-    least 2. These have already merged as many immediate-diagonal neighbors as possible.
+    Returns a tuple of (segments, segment_matrix). These are a list of
+    _SegmentUnionFinds and a 2D array whose values are all either 0 or those
+    same _SegmentUnionFinds, each of which has size at least 2. These have
+    already merged as many immediate-diagonal neighbors as possible.
     """
     nr, nc = matrix.shape
 
@@ -71,9 +72,10 @@ def _initialize_segments(matrix, is_single_file):
         for c in range(nc):
             if matrix[r, c] == 0:
                 continue
-            # An optimization: lone pixels that don't have anything immediately diagonal from them
-            # can never grow. So, as we initialize things, grow each segment as long as it can be
-            # with a straight diagonal, and don't bother initializing anything of size 1.
+            # An optimization: lone pixels that don't have anything immediately
+            # diagonal from them can never grow. So, as we initialize things,
+            # grow each segment as long as it can be with a straight diagonal,
+            # and don't bother initializing anything of size 1.
             if segment_matrix[r, c] != 0:
                 continue  # Already added as part of a contiguous segment.
             if r == c and is_single_file:
@@ -81,13 +83,15 @@ def _initialize_segments(matrix, is_single_file):
 
             # See whether this segment is more than just a dot.
             size = 1
-            while r + size < nr and c + size < nc and matrix[r + size, c + size] != 0:
+            while (r + size < nr and c + size < nc and
+                   matrix[r + size, c + size] != 0):
                 size += 1
 
-            if size == 1:  # This is a trivial segment. Don't bother trying to merge more.
+            if size == 1:  # Trivial segment: Don't bother trying to merge more.
                 continue
             # Otherwise, we've found a nontrivial segment. Add it in!
-            new_segment = _SegmentUnionFind((r, c), (r + size - 1, c + size - 1), size)
+            new_segment = _SegmentUnionFind(
+                    (r, c), (r + size - 1, c + size - 1), size)
             for i in range(size):
                 segment_matrix[r + i, c + i] = new_segment
             segments.append(new_segment)

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -72,6 +72,8 @@ def _get_lengths(matrix, is_single_file):
     segments = []
     for r in range(nr):
         for c in range(nc):
+            if matrix[r, c] == 0:
+                continue
             # An optimization: lone pixels that don't have anything immediately diagonal from them
             # can never grow. So, as we initialize things, grow each segment as long as it can be
             # with a straight diagonal, and don't bother initializing anything of size 1.
@@ -79,12 +81,12 @@ def _get_lengths(matrix, is_single_file):
                 continue  # Already added as part of a contiguous segment.
             if r == c and is_single_file:
                 continue  # Skip pixels on the main diagonal
-            if matrix[r, c] == 0:
-                continue
+
             # See whether this segment is more than just a dot.
             size = 0
             while r + size < nr and c + size < nc and matrix[r + size, c + size] != 0:
                 size += 1
+
             if size == 1:  # This is a trivial segment. Don't bother trying to merge more.
                 continue
             # Otherwise, we've found a nontrivial segment. Add it in!

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -10,6 +10,12 @@ class _SegmentUnionFind:
     from the usual one because it represents a set of duplicated tokens, with a
     top-right and bottom-left coordinate, in addition to the size.
     """
+    # Save memory by telling Python exactly what fields we use, which means the
+    # Python interpreter doesn't allocate a dict for all the extra fields we
+    # might add later. This reduces the memory usage of _SegmentUnionFind by
+    # roughly two thirds.
+    __slots__ = ("_size", "_root", "top", "bottom")
+
     def __init__(self, top, bottom, size):
         self._size = size
         self._root = None  # Might be another _SegmentUnionFind after merging

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -158,11 +158,11 @@ def get_lengths(matrix, is_single_file):
 
 def _find_mergeable_segment(current, pixel_to_segment, max_distance, shape):
     """
-    current is a _SegmentUnionFind, and pixel_to_segment is a 2D array of such
-    objects. We return the largest _SegmentUnionFind below-right of current that
-    we can merge with, or None if none are available. We only look at most
-    max_distance away from the location diagonal from current's bottom-right
-    corner (using the Manhattan distance).
+    current is a _SegmentUnionFind, and pixel_to_segment is a dict mapping pixel
+    coordinates to _SegmentUnionFind objects. We return the largest
+    _SegmentUnionFind below-right of current that we can merge with, or None if
+    none are available. We only look at most max_distance away from the location
+    diagonal from current's bottom-right corner (using the Manhattan distance).
 
     Two segments are mergeable if the Manhattan distance between the
     bottom-right end of one and the top-left end of the other is at most 2 more

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -70,19 +70,15 @@ class _SegmentUnionFind:
 def _initialize_segments(matrix, is_single_file):
     """
     Returns a tuple of (segments, pixel_to_segment). These are a list of
-    _SegmentUnionFinds and a dict mapping coordinates to the _SegmentUnionFinds
-    they make up (same ones as in the list).  Each _SegmentUnionFind has size
-    at least 2: these have already merged as many immediate-diagonal neighbors
-    as possible.
+    _SegmentUnionFinds and a dict mapping pixel coordinates to the
+    _SegmentUnionFinds they make up (same ones as in the list).  Each
+    _SegmentUnionFind has size at least 2: these have already merged as many
+    immediate-diagonal neighbors as possible.
     """
     nr, nc = matrix.shape
 
-    # Initialization: pixel_to_segment has the same shape as matrix, but is either
-    # full of 0's or _SegmentUnionFind objects. segments will be an iterable
-    # (either a list or a set) containing those same objects.
-    #pixel_to_segment = numpy.zeros((nr, nc), dtype=numpy.object_)
-    pixel_to_segment = {}
     segments = []
+    pixel_to_segment = {}
     for r in range(nr):
         for c in range(nc):
             if matrix[r, c] == 0:
@@ -102,13 +98,13 @@ def _initialize_segments(matrix, is_single_file):
                    matrix[r + size, c + size] != 0):
                 size += 1
 
-            if size == 1:  # Trivial segment: Don't bother trying to merge more.
+            if size == 1:  # Trivial segment: don't bother
                 continue
             # Otherwise, we've found a nontrivial segment. Add it in!
             new_segment = _SegmentUnionFind(r, c, size)
+            segments.append(new_segment)
             for i in range(size):
                 pixel_to_segment[(r + i, c + i)] = new_segment
-            segments.append(new_segment)
     return segments, pixel_to_segment
 
 

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -108,7 +108,7 @@ def _initialize_segments(matrix, is_single_file):
     return segments, pixel_to_segment
 
 
-def _get_lengths(matrix, is_single_file):
+def get_lengths(matrix, is_single_file):
     """
     matrix is a 2D numpy array of uint8s. We return a 2D numpy array of uint32s,
     which are a measure of how long a chain of nonzero values from the original
@@ -215,7 +215,7 @@ def _find_mergeable_segment(current, pixel_to_segment, max_distance, shape):
 
 
 def get_hues(matrix, is_single_file):
-    scores = _get_lengths(matrix, is_single_file)
+    scores = get_lengths(matrix, is_single_file)
     # Cut everything off at the max, then divide by the max to put all values
     # between 0 and 1.
     scores = numpy.minimum(

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -12,12 +12,12 @@ class _SegmentUnionFind:
     """
     def __init__(self, r, c):
         self._size = 1
-        self._root = self
+        self._root = None  # Might become a reference to another _SegmentUnionFind after merging
         self.top = (r, c)
         self.bottom = (r, c)
 
     def get_root(self):
-        if self._root is self:
+        if self._root is None:
             return self
 
         self._root = self._root.get_root()

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -147,18 +147,15 @@ def _get_lengths(matrix, is_single_file):
     # Finally, output the final sizes of all the _SegmentUnionFinds as the final
     # scores.
     nr, nc = matrix.shape
-    scores = numpy.zeros((nr, nc), dtype=numpy.uint32)
+    # For every pixel not involved in a segment, its score is 0 if it was not
+    # set in the original, and 1 if it was (it's either a lone pixel or it's on
+    # the main diagonal of a file compared to itself).
+    scores = (matrix != 0).astype(numpy.uint32)
     for r in range(nr):
         for c in range(nc):
             segment = pixel_to_segment.get((r, c))
             if segment is not None:
                 scores[r, c] = segment.size()
-            elif matrix[r, c] != 0:
-                # The pixel was set in the original matrix, but we didn't
-                # create a segment for it.  Either it's a lone pixel by itself,
-                # or it's on the main diagonal of a file compared to itself.
-                # Either way, it scores 1.
-                scores[r, c] = 1
     return scores
 
 

--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -17,6 +17,13 @@ class _SegmentUnionFind:
     __slots__ = ("_size", "_root", "top", "bottom")
 
     def __init__(self, r, c, size):
+        """
+        The arguments passed in are the coordinates of the top-left pixel, and
+        the number of pixels on a straight diagonal line to the end of this
+        segment. We do this to avoid allocating a bunch of 1-pixel segments
+        that are either never going to be used or about to be joined with their
+        immediate diagonals.
+        """
         self._size = size
         self._root = None  # Might be another _SegmentUnionFind after merging
         self.top = (r, c)
@@ -63,9 +70,10 @@ class _SegmentUnionFind:
 def _initialize_segments(matrix, is_single_file):
     """
     Returns a tuple of (segments, segment_matrix). These are a list of
-    _SegmentUnionFinds and a 2D array whose values are all either 0 or those
-    same _SegmentUnionFinds, each of which has size at least 2. These have
-    already merged as many immediate-diagonal neighbors as possible.
+    _SegmentUnionFinds and a dict mapping coordinates to the _SegmentUnionFinds
+    they make up (same ones as in the list).  Each _SegmentUnionFind has size
+    at least 2: these have already merged as many immediate-diagonal neighbors
+    as possible.
     """
     nr, nc = matrix.shape
 

--- a/gui.py
+++ b/gui.py
@@ -147,7 +147,10 @@ def launch(matrix, hues, data_a, data_b, map_width, text_width):
     for char in "wWqQ":
         root.bind("<Control-{}>".format(char), _quit)
 
-    gui = _Gui(matrix, hues, data_a, data_b, map_width, text_width, root)
+    # We construct a _Gui object, but don't bother holding on to a reference to
+    # it because we're never going to touch it again. It doesn't get garbage
+    # collected because `root` holds a reference to it.
+    _Gui(matrix, hues, data_a, data_b, map_width, text_width, root)
     while True:
         try:
             root.mainloop()

--- a/gui.py
+++ b/gui.py
@@ -1,4 +1,3 @@
-from functools import partial
 from math import ceil
 import tkinter as tk
 import tkinter.font as tkfont

--- a/visual_diff.py
+++ b/visual_diff.py
@@ -140,6 +140,9 @@ if __name__ == "__main__":
     # TODO: it might be cool to allow comparisons across languages.
     with open(args.filename_b or args.filename_a) as f_b:
         data_b = get_tokens(f_b.read(), language)
+    print(f"Comparing a file with {len(data_a.tokens)} tokens to "
+          f"one that has {len(data_b.tokens)}: final image has "
+          f"{len(data_a.tokens) * len(data_b.tokens)} pixels.")
     matrix = make_matrix(data_a.tokens, data_b.tokens)
 
     if args.color:


### PR DESCRIPTION
This fixes a subtle problem. Python's garbage collector is based on reference counting, and when a `_SegmentUnionFind` stores a reference to itself in `self._root`, it cannot be garbage collected. So, the changes to that are able to reclaim a whole bunch of memory after colorizing the images is complete.

In addition, this PR adds a useful optimization: segments of size 1 can only merge with their immediate neighbors. So, while initializing, grow the segment as long as possible along a diagonal, and if it's only 1 pixel long, don't bother creating a `_SegmentUnionFind` for it. This cuts the amount of memory used on the largest file I've tried from over 85% of my RAM to only about 40%. 

Finally, I split the initialization out to a separate function, because the function was getting so long.