### PR TITLE
Update test to match new code

### DIFF
--- a/find_duplicates.py
+++ b/find_duplicates.py
@@ -62,9 +62,7 @@ class _SegmentUnionFind:
 
     def __str__(self):  # Used solely for debugging
         root = self.get_root()
-        return (f"(Segment size {root.size()} "
-                f"from ({root.top_r}, {root.top_c}) "
-                f"to ({root.bottom_r}, {root.bottom_c}))")
+        return f"(Segment size {root.size()} from {root.top} to {root.bottom})"
 
 
 def _initialize_segments(matrix, is_single_file):

--- a/generate_report.py
+++ b/generate_report.py
@@ -86,7 +86,7 @@ def compare_files(data_a, data_b, min_segment_size, include_big_files=False):
     return results
 
 
-def compare_all_files(file_data, min_segment_size, include_big_files):
+def compare_all_files(file_data, min_segment_size, include_big_files=False):
     """
     Returns a list of strings that should be shown in a report about
     duplication within these files.

--- a/generate_report_test.py
+++ b/generate_report_test.py
@@ -2,13 +2,14 @@
 import unittest
 
 import generate_report
+import tokenizer
 
 
 class TestGenerateReports(unittest.TestCase):
     def test_file_against_self(self):
-        actual = generate_report.compare_files("examples/pointsprite.py",
-                                               "examples/pointsprite.py",
-                                               "python", 100)
+        pointsprite_info = tokenizer.get_file_tokens("examples/pointsprite.py")
+        actual = generate_report.compare_files(
+                pointsprite_info, pointsprite_info, 100)
         expected = [
             "Found duplicated code between examples/pointsprite.py and examples/pointsprite.py:",
             "    706 tokens on lines 28-121 and lines 121-295",

--- a/generate_report_test.py
+++ b/generate_report_test.py
@@ -21,21 +21,23 @@ class TestGenerateReports(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_file_pair(self):
+        nmea_info = tokenizer.get_file_tokens("examples/gpsnmea.go")
+        rtk_info = tokenizer.get_file_tokens("examples/gpsrtk.go")
         actual = generate_report.compare_all_files(
-            ["examples/gpsnmea.go", "examples/gpsrtk.go"], "go", 100)
+            [nmea_info, rtk_info], 100)
         expected = [
             "Found duplicated code between examples/gpsnmea.go and examples/gpsrtk.go:",
-            "    413 tokens on lines 61-123 and lines 77-144",
+            "    413 tokens on lines 69-131 and lines 85-152",
             "Found duplicated code between examples/gpsrtk.go and examples/gpsrtk.go:",
-            "    120 tokens on lines 270-308 and lines 304-344",
-            "    116 tokens on lines 344-355 and lines 479-490",
-            "    142 tokens on lines 387-415 and lines 438-464",
-            "    362 tokens on lines 551-610 and lines 559-618",
-            "    305 tokens on lines 551-602 and lines 567-618",
-            "    251 tokens on lines 551-594 and lines 575-618",
-            "    212 tokens on lines 551-586 and lines 583-618",
-            "    130 tokens on lines 551-570 and lines 599-618",
-            "    164 tokens on lines 554-578 and lines 594-618",
+            "    120 tokens on lines 278-316 and lines 312-352",
+            "    116 tokens on lines 352-363 and lines 487-498",
+            "    142 tokens on lines 395-423 and lines 446-472",
+            "    362 tokens on lines 559-618 and lines 567-626",
+            "    305 tokens on lines 559-610 and lines 575-626",
+            "    251 tokens on lines 559-602 and lines 583-626",
+            "    212 tokens on lines 559-594 and lines 591-626",
+            "    130 tokens on lines 559-578 and lines 607-626",
+            "    164 tokens on lines 562-586 and lines 602-626",
             ]
         self.assertEqual(expected, actual)
 

--- a/generate_report_test.py
+++ b/generate_report_test.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python3
-from parameterized import parameterized
-import PIL.Image
-import PIL.ImageChops
 import unittest
 
 import generate_report


### PR DESCRIPTION
- I removed the use of backticks in `examples/gps*.go` because they're parsed differently in different versions of tree-sitter. However, I forgot to update the integration test with the new line numbers.
- I changed several of the functions in generate_report.py to take `FileInfo` objects instead of filenames, and forgot to update the tests to match.